### PR TITLE
fix: modal overlay opacity

### DIFF
--- a/src/components/Modal/Modal.module.css
+++ b/src/components/Modal/Modal.module.css
@@ -28,7 +28,6 @@
   max-width: 600px;
   height: fit-content;
   padding: 10px 20px 50px 20px;
-  opacity: 1;
   color: var(--color-gray-text);
 }
 

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -9,7 +9,8 @@ export interface Props {
 
 export const Modal: React.FC<Props> = ({ children, buttons, title }) => {
   return (
-    <div className={styles.modalOverlay}>
+    <div>
+      <div className={styles.modalOverlay} />
       <DialogModal open className={styles.modal}>
         <div className={styles.modalTitleWrapper}>
           <span className={styles.modalTitle}>{title}</span>


### PR DESCRIPTION
## fixes KILTProtocol/ticket#1544
This PR fixes the modal opacity bug

## How to test:
- open a modal in firefox

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
