### PR TITLE
fix: errors showing twice

### DIFF
--- a/src/utils/chain.ts
+++ b/src/utils/chain.ts
@@ -122,6 +122,9 @@ async function signAndSend(
 ) {
   const api = await getConnection()
   const injector = await web3FromAddress(address)
+
+  let hadError = false
+
   return tx.signAndSend(
     address,
     { signer: injector.signer },
@@ -129,7 +132,8 @@ async function signAndSend(
       if (status.isInBlock) {
         onSuccess()
       }
-      if (dispatchError) {
+      if (dispatchError && !hadError) {
+        hadError = true
         if (dispatchError.isModule) {
           // for module errors, we have the section indexed, lookup
           const decoded = api.registry.findMetaError(dispatchError.asModule)


### PR DESCRIPTION
## fixes KILTProtocol/ticket#1573
This PR prevents errors showing twice.
In effect this will always just show the first error a transaction produces and ignore the rest.

## How to test:
- Retest the ticket

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
