### PR TITLE
feat: prevent multi signature requests

### DIFF
--- a/src/container/BlockchainNotification/BlockchainNotification.tsx
+++ b/src/container/BlockchainNotification/BlockchainNotification.tsx
@@ -6,10 +6,29 @@ import { StateContext } from '../../utils/StateContext'
 export const BlockchainNotication: React.FC = () => {
   const {
     state: {
-      transaction: { txHash, isInProgress },
+      transaction: { txHash, isInProgress, needsSignature },
     },
     dispatch,
   } = useContext(StateContext)
+
+  if (needsSignature) {
+    return (
+      <Modal
+        title="SIGNATURE NEEDED"
+        buttons={
+          <Button
+            onClick={() => dispatch({ type: 'resetTransaction' })}
+            label={'close'}
+          />
+        }
+      >
+        <p>
+          Please wait for your Wallet Extension to open and sign the transaction
+          there.
+        </p>
+      </Modal>
+    )
+  }
 
   if (isInProgress) {
     return (

--- a/src/state/reducers.ts
+++ b/src/state/reducers.ts
@@ -23,6 +23,9 @@ export type ErrorActions =
 
 export type TransactionActions =
   | {
+      type: 'needsSignature'
+    }
+  | {
       type: 'transactionInProgress'
     }
   | {
@@ -102,6 +105,7 @@ export const connectionReducer: Reducer<ConnectionState, Actions> = (
 
 export type TransactionState = {
   isInProgress: boolean
+  needsSignature: boolean
   txHash?: string
 }
 
@@ -110,18 +114,24 @@ export const transactionReducer: Reducer<TransactionState, Actions> = (
   action
 ) => {
   switch (action.type) {
+    case 'needsSignature': {
+      return { isInProgress: false, needsSignature: true }
+    }
     case 'transactionInProgress':
       return {
         isInProgress: true,
+        needsSignature: false,
       }
     case 'transactionFinished':
       return {
         txHash: action.txHash,
         isInProgress: false,
+        needsSignature: false,
       }
     case 'resetTransaction':
       return {
         isInProgress: false,
+        needsSignature: false,
       }
     default:
       return state

--- a/src/utils/StateContext.tsx
+++ b/src/utils/StateContext.tsx
@@ -31,6 +31,7 @@ export const StateContext = React.createContext<{
     connection: { status: 'disconnected' },
     transaction: {
       isInProgress: false,
+      needsSignature: false,
     },
   },
   dispatch: () => null,
@@ -55,6 +56,7 @@ export const StateProvider: React.FC = ({ children }) => {
     connection: { status: 'disconnected' },
     transaction: {
       isInProgress: false,
+      needsSignature: false,
     },
   })
 

--- a/src/utils/useTxSubmitter.ts
+++ b/src/utils/useTxSubmitter.ts
@@ -16,10 +16,12 @@ export const useTxSubmitter = () => {
 
   const signAndSubmitTx = async (address: string, tx: SubmittableExtrinsic) => {
     try {
+      dispatch({ type: 'needsSignature' })
       await signAndSend(address, tx, onSuccess, onError)
       dispatch({ type: 'transactionInProgress' })
     } catch (e) {
       console.error(e)
+      dispatch({ type: 'resetTransaction' })
     }
   }
 


### PR DESCRIPTION
## fixes KILTProtocol/ticket#1600
This PR prevents multiple signature requests, by introducing a `needsSignature` state and showing a modal for when the user has to wait for the extension to pop up.

## How to test:
- Try to do a staking action
- when extension pops up, a modal should be seen

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
