### PR TITLE
refactor: convert useBlockchainData to be a context giving container

### DIFF
--- a/src/components/ChainInfo/ChainInfo.tsx
+++ b/src/components/ChainInfo/ChainInfo.tsx
@@ -4,25 +4,19 @@ import { StateContext } from '../../utils/StateContext'
 import styles from './ChainInfo.module.css'
 import cx from 'classnames'
 import { Icon } from '../Icon/Icon'
-import { ChainTypes } from '../../types'
+import { BlockchainDataContext } from '../../utils/BlockchainDataContext'
 
-type Props = {
-  sessionInfo?: ChainTypes.RoundInfo
-  bestBlock?: ChainTypes.BlockNumber
-  bestFinalisedBlock?: ChainTypes.BlockNumber
-}
-
-export const ChainInfo: React.FC<Props> = ({
-  sessionInfo,
-  bestBlock,
-  bestFinalisedBlock,
-}) => {
+export const ChainInfo: React.FC = ({}) => {
   const [sessionCount, setSessionCount] = useState<number>()
   const [sessionCountdown, setSessionCountdown] = useState('')
 
   const {
     state: { refreshPaused },
   } = useContext(StateContext)
+
+  const { sessionInfo, bestBlock, bestFinalisedBlock } = useContext(
+    BlockchainDataContext
+  )
 
   useEffect(() => {
     const sessionCount = sessionCounter(sessionInfo, bestBlock)

--- a/src/components/CollatorList/CollatorList.stories.tsx
+++ b/src/components/CollatorList/CollatorList.stories.tsx
@@ -1,6 +1,7 @@
 import { Story, Meta } from '@storybook/react'
+import { BlockchainDataContext } from '../../utils/BlockchainDataContext'
 
-import { CollatorList, Props } from './CollatorList'
+import { CollatorList } from './CollatorList'
 
 export default {
   title: 'CollatorList',
@@ -8,126 +9,133 @@ export default {
   argTypes: {},
 } as Meta
 
-const Template: Story<Props> = (args) => <CollatorList {...args} />
-
-export const Primary = Template.bind({})
-Primary.args = {
-  accounts: [
-    {
-      address: '5F1P7WAgEkh7YWCHCBcnBx8Gvx2VbCMrjezUjiJRoZmmR464',
-      name: 'KILT Identity 1',
-      stakeable: 100_000,
-      staked: 0,
-      unstaking: [],
-    },
-    {
-      address: '5GN6CNx5L44Ga372PvyD639ukHTvoUktkDCNL4rY7sEFy57P',
-      name: 'KILT Identity 2',
-      stakeable: 800_000,
-      staked: 0,
-      unstaking: [],
-    },
-    {
-      address: '5D7WMHRftdGWGhfAP7NaJfKuRyvfES77ZnjcBzqgMFMjTsGu',
-      name: 'KILT Identity 3',
-      stakeable: 10_000,
-      staked: 0,
-      unstaking: [],
-    },
-  ],
-  dataSet: [
-    {
-      collator: '5HTySzbJiBYuJow2ZKSHJTnMHF14S8oNnkkEBzzhyqaAPTAH',
-      active: true,
-      activeNext: false,
-      isLeaving: false,
-      totalStake: 200_000,
-      delegators: 5,
-      lowestStake: 10_000,
-      stakes: [],
-      favorite: true,
-    },
-    {
-      collator: '5DLYuqjWyEFWF6c4oVDh62L4cPZajvupNj6uUNS4tBSux3ay',
-      active: true,
-      activeNext: true,
-      isLeaving: false,
-      totalStake: 400_000,
-      delegators: 15,
-      lowestStake: 15_000,
-      stakes: [
+const Template: Story = (args) => (
+  <BlockchainDataContext.Provider
+    value={{
+      accounts: [
         {
-          stake: 100_000,
-          account: '5D7WMHRftdGWGhfAP7NaJfKuRyvfES77ZnjcBzqgMFMjTsGu',
+          address: '5F1P7WAgEkh7YWCHCBcnBx8Gvx2VbCMrjezUjiJRoZmmR464',
+          name: 'KILT Identity 1',
+          stakeable: 100_000,
+          staked: 0,
+          unstaking: [],
+        },
+        {
+          address: '5GN6CNx5L44Ga372PvyD639ukHTvoUktkDCNL4rY7sEFy57P',
+          name: 'KILT Identity 2',
+          stakeable: 800_000,
+          staked: 0,
+          unstaking: [],
+        },
+        {
+          address: '5D7WMHRftdGWGhfAP7NaJfKuRyvfES77ZnjcBzqgMFMjTsGu',
+          name: 'KILT Identity 3',
+          stakeable: 10_000,
+          staked: 0,
+          unstaking: [],
         },
       ],
-      favorite: false,
-    },
-    {
-      collator: '5GQtYZsBDvgXq2KSffpN9HWxtK8rxG4gk1jWSp5MaDb1gurR',
-      active: true,
-      activeNext: true,
-      isLeaving: true,
-      totalStake: 600_000,
-      delegators: 25,
-      lowestStake: 20_000,
-      stakes: [],
-      favorite: false,
-    },
-    {
-      collator: '4siCnobG887X3dG4NA9EQn1HWF11pogAAdNmGBnyH2uN4CQM',
-      active: false,
-      activeNext: false,
-      isLeaving: false,
-      totalStake: 10_000,
-      delegators: 0,
-      lowestStake: 0,
-      stakes: [],
-      favorite: false,
-    },
-    {
-      collator: '4tBHgCpZZVyhY4pGg5rHMYj6j5TMuPG7vtcpK28Cpy1c5o8h',
-      active: false,
-      activeNext: true,
-      isLeaving: false,
-      totalStake: 100_000,
-      delegators: 2,
-      lowestStake: 15_000,
-      stakes: [],
-      favorite: false,
-    },
-    {
-      collator: '4rBMZdMBa8JD9oghH3Djukof7RAiMgJb28vHNqSJ54EKKpQ2',
-      active: true,
-      activeNext: true,
-      isLeaving: false,
-      totalStake: 150_000,
-      delegators: 1,
-      lowestStake: 50_000,
-      stakes: [],
-      favorite: false,
-    },
-    {
-      collator: '4rC1U8kMf3icQZPLH5cJ5q8yE5ozEnka5rUQtxe7A1uRG1G1',
-      active: true,
-      activeNext: false,
-      isLeaving: false,
-      totalStake: 20_000,
-      delegators: 1,
-      lowestStake: 10_000,
-      stakes: [],
-      favorite: false,
-    },
-    {
-      collator: '4rDeMGr3Hi4NfxRUp8qVyhvgW3BSUBLneQisGa9ASkhh2sXB',
-      active: true,
-      activeNext: true,
-      isLeaving: false,
-      totalStake: 200_000,
-      delegators: 0,
-      lowestStake: 0,
-      stakes: [],
-      favorite: false,
-    },
-  ],
-}
+      dataSet: [
+        {
+          collator: '5HTySzbJiBYuJow2ZKSHJTnMHF14S8oNnkkEBzzhyqaAPTAH',
+          active: true,
+          activeNext: false,
+          isLeaving: false,
+          totalStake: 200_000,
+          delegators: 5,
+          lowestStake: 10_000,
+          stakes: [],
+          favorite: true,
+        },
+        {
+          collator: '5DLYuqjWyEFWF6c4oVDh62L4cPZajvupNj6uUNS4tBSux3ay',
+          active: true,
+          activeNext: true,
+          isLeaving: false,
+          totalStake: 400_000,
+          delegators: 15,
+          lowestStake: 15_000,
+          stakes: [
+            {
+              stake: 100_000,
+              account: '5D7WMHRftdGWGhfAP7NaJfKuRyvfES77ZnjcBzqgMFMjTsGu',
+            },
+          ],
+          favorite: false,
+        },
+        {
+          collator: '5GQtYZsBDvgXq2KSffpN9HWxtK8rxG4gk1jWSp5MaDb1gurR',
+          active: true,
+          activeNext: true,
+          isLeaving: true,
+          totalStake: 600_000,
+          delegators: 25,
+          lowestStake: 20_000,
+          stakes: [],
+          favorite: false,
+        },
+        {
+          collator: '4siCnobG887X3dG4NA9EQn1HWF11pogAAdNmGBnyH2uN4CQM',
+          active: false,
+          activeNext: false,
+          isLeaving: false,
+          totalStake: 10_000,
+          delegators: 0,
+          lowestStake: 0,
+          stakes: [],
+          favorite: false,
+        },
+        {
+          collator: '4tBHgCpZZVyhY4pGg5rHMYj6j5TMuPG7vtcpK28Cpy1c5o8h',
+          active: false,
+          activeNext: true,
+          isLeaving: false,
+          totalStake: 100_000,
+          delegators: 2,
+          lowestStake: 15_000,
+          stakes: [],
+          favorite: false,
+        },
+        {
+          collator: '4rBMZdMBa8JD9oghH3Djukof7RAiMgJb28vHNqSJ54EKKpQ2',
+          active: true,
+          activeNext: true,
+          isLeaving: false,
+          totalStake: 150_000,
+          delegators: 1,
+          lowestStake: 50_000,
+          stakes: [],
+          favorite: false,
+        },
+        {
+          collator: '4rC1U8kMf3icQZPLH5cJ5q8yE5ozEnka5rUQtxe7A1uRG1G1',
+          active: true,
+          activeNext: false,
+          isLeaving: false,
+          totalStake: 20_000,
+          delegators: 1,
+          lowestStake: 10_000,
+          stakes: [],
+          favorite: false,
+        },
+        {
+          collator: '4rDeMGr3Hi4NfxRUp8qVyhvgW3BSUBLneQisGa9ASkhh2sXB',
+          active: true,
+          activeNext: true,
+          isLeaving: false,
+          totalStake: 200_000,
+          delegators: 0,
+          lowestStake: 0,
+          stakes: [],
+          favorite: false,
+        },
+      ],
+    }}
+  >
+    {' '}
+    <CollatorList {...args} />
+  </BlockchainDataContext.Provider>
+)
+
+export const Primary = Template.bind({})
+Primary.args = {}

--- a/src/components/CollatorList/CollatorList.tsx
+++ b/src/components/CollatorList/CollatorList.tsx
@@ -1,16 +1,11 @@
-import React, { useEffect, useState } from 'react'
+import React, { useContext, useEffect, useState } from 'react'
 import cx from 'classnames'
 import styles from './CollatorList.module.css'
 import rowStyles from '../../styles/row.module.css'
 import { CollatorListItem } from '../CollatorListItem/CollatorListItem'
 import { Icon } from '../Icon/Icon'
-import { Account, Data } from '../../types'
 import { Input } from '../Input/Input'
-
-export interface Props {
-  dataSet: Data[]
-  accounts: Account[]
-}
+import { BlockchainDataContext } from '../../utils/BlockchainDataContext'
 
 enum SORT_BY {
   Rank,
@@ -25,7 +20,8 @@ function iconSortType(actual: number, expect: number) {
   return actual === expect ? 'order_yellow' : 'order_white'
 }
 
-export const CollatorList: React.FC<Props> = ({ dataSet, accounts }) => {
+export const CollatorList: React.FC = () => {
+  const { dataSet } = useContext(BlockchainDataContext)
   const [showSearch, setShowSearch] = useState(false)
   const [search, setSearch] = useState('')
   const [sortBy, setSortBy] = useState(SORT_BY.Rank)
@@ -147,7 +143,6 @@ export const CollatorList: React.FC<Props> = ({ dataSet, accounts }) => {
       <tbody className={styles.tableBody}>
         {data.map((entry) => (
           <CollatorListItem
-            accounts={accounts}
             entry={entry}
             rank={ranks.get(entry.collator)}
             key={entry.collator}

--- a/src/components/CollatorListItem/CollatorListItem.tsx
+++ b/src/components/CollatorListItem/CollatorListItem.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useState } from 'react'
-import { Account, Data } from '../../types'
+import { Data } from '../../types'
 import styles from './CollatorListItem.module.css'
 import rowStyles from '../../styles/row.module.css'
 import { StakeRow } from '../StakeRow/StakeRow'
@@ -10,16 +10,11 @@ import { StoredStateContext } from '../../utils/StoredStateContext'
 export interface Props {
   entry: Data
   rank: number | undefined
-  accounts: Account[]
 }
 
 const COLS = 7
 
-export const CollatorListItem: React.FC<Props> = ({
-  entry,
-  rank,
-  accounts,
-}) => {
+export const CollatorListItem: React.FC<Props> = ({ entry, rank }) => {
   const [expanded, setExpanded] = useState(false)
   const {
     state: { termsAccepted },
@@ -39,21 +34,14 @@ export const CollatorListItem: React.FC<Props> = ({
             <StakeRow
               key={stakeInfo.account}
               stakeInfo={stakeInfo}
-              accounts={accounts}
               collator={entry.collator}
             />
           ))}
-          {
-            <NewStakeRow
-              accounts={accounts}
-              staked={true}
-              collator={entry.collator}
-            />
-          }
+          {<NewStakeRow staked={true} collator={entry.collator} />}
         </>
       )}
       {termsAccepted && expanded && entry.stakes.length === 0 && (
-        <NewStakeRow accounts={accounts} collator={entry.collator} />
+        <NewStakeRow collator={entry.collator} />
       )}
       <tr className={styles.lastRow}>
         <td className={rowStyles.spacer}></td>

--- a/src/components/Dashboard/Accounts.tsx
+++ b/src/components/Dashboard/Accounts.tsx
@@ -1,13 +1,10 @@
-import React from 'react'
+import React, { useContext } from 'react'
 import styles from './Accounts.module.css'
 import { Account, AccountWithPct } from '../../types'
 import { TokenBar } from './TokenBar'
 import { MetaDown, MetaUp } from './Meta'
 import { UnusedMeta } from './Meta'
-
-export interface Props {
-  accounts: Account[]
-}
+import { BlockchainDataContext } from '../../utils/BlockchainDataContext'
 
 export interface UnusedAccountsProps {
   accounts: Account[]
@@ -28,7 +25,8 @@ export const UnusedAccounts: React.FC<UnusedAccountsProps> = ({
   )
 }
 
-export const Accounts: React.FC<Props> = ({ accounts }) => {
+export const Accounts: React.FC = () => {
+  const { accounts } = useContext(BlockchainDataContext)
   const usedAccounts = accounts.filter((account) => account.used)
   const unusedAccounts = accounts.filter((account) => !account.used)
 

--- a/src/components/Dashboard/Dashboard.stories.tsx
+++ b/src/components/Dashboard/Dashboard.stories.tsx
@@ -1,6 +1,7 @@
 import { Story, Meta } from '@storybook/react'
 import { Dashboard, Props } from './Dashboard'
 import { Account } from '../../types'
+import { BlockchainDataContext } from '../../utils/BlockchainDataContext'
 
 export default {
   title: 'Dashboard',
@@ -38,21 +39,6 @@ interface PropsWithCustom extends Props {
   stakeable1: number
   staked2: number
   stakeable2: number
-}
-
-const Template: Story<PropsWithCustom> = ({
-  staked1,
-  stakeable1,
-  staked2,
-  stakeable2,
-  accounts,
-  ...args
-}) => {
-  accounts[0].staked = staked1
-  accounts[0].stakeable = stakeable1
-  accounts[1].staked = staked2
-  accounts[1].stakeable = stakeable2
-  return <Dashboard accounts={accounts} {...args} />
 }
 
 const accounts: Account[] = [
@@ -98,9 +84,27 @@ const accounts: Account[] = [
   },
 ]
 
+const Template: Story<PropsWithCustom> = ({
+  staked1,
+  stakeable1,
+  staked2,
+  stakeable2,
+  ...args
+}) => {
+  accounts[0].staked = staked1
+  accounts[0].stakeable = stakeable1
+  accounts[1].staked = staked2
+  accounts[1].stakeable = stakeable2
+
+  return (
+    <BlockchainDataContext.Provider value={{ accounts, dataSet: [] }}>
+      <Dashboard {...args} />
+    </BlockchainDataContext.Provider>
+  )
+}
+
 export const Primary = Template.bind({})
 Primary.args = {
-  accounts,
   staked1: 14_000,
   stakeable1: 8_000,
   staked2: 5_000,

--- a/src/components/Dashboard/Dashboard.tsx
+++ b/src/components/Dashboard/Dashboard.tsx
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react'
 import styles from './Dashboard.module.css'
-import { Account, ChainTypes, Extension } from '../../types'
+import { Extension } from '../../types'
 import { Accounts } from './Accounts'
 import { StateContext } from '../../utils/StateContext'
 import { IdentityView } from '../../container/IdentityView/IdentityView'
@@ -9,9 +9,7 @@ import { Onboarding } from '../Onboarding/Onboarding'
 import { Overlays } from '../Overlays/Overlays'
 
 export interface Props {
-  accounts: Account[]
   extensions: Extension[]
-  bestBlock?: ChainTypes.BlockNumber
 }
 
 type RefreshPausedOverlayProps = {
@@ -28,28 +26,24 @@ const RefreshPausedOverlay: React.FC<RefreshPausedOverlayProps> = ({
     <>{children}</>
   )
 
-export const Dashboard: React.FC<Props> = ({
-  accounts,
-  bestBlock,
-  extensions,
-}) => {
+export const Dashboard: React.FC<Props> = ({ extensions }) => {
   const {
     state: { refreshPaused, account },
   } = useContext(StateContext)
 
   return (
     <div className={styles.dashboard}>
-      <Onboarding accounts={accounts} extensions={extensions}>
+      <Onboarding extensions={extensions}>
         <Overlays>
           <RefreshPausedOverlay refreshPaused={refreshPaused}>
             {account ? (
-              <IdentityView bestBlock={bestBlock} />
+              <IdentityView />
             ) : (
               <>
                 <div className={styles.accountsContainer}>
                   <>
                     <div className={styles.accounts}>
-                      <Accounts accounts={accounts} />
+                      <Accounts />
                     </div>
                   </>
                 </div>

--- a/src/components/NewStakeRow/NewStakeRow.tsx
+++ b/src/components/NewStakeRow/NewStakeRow.tsx
@@ -1,28 +1,24 @@
-import React, { useMemo, useState } from 'react'
+import React, { useContext, useMemo, useState } from 'react'
 import cx from 'classnames'
 import rowStyles from '../../styles/row.module.css'
 import { Button } from '../Button/Button'
 import { Input } from '../Input/Input'
 import { IdentitySelector } from '../../container/IdentitySelector/IdentitySelector'
-import { Account } from '../../types'
 import { useModal } from '../../utils/useModal'
 import { StakeModal } from '../StakeModal/StakeModal'
 import { getStatus } from '../../utils/stakeStatus'
 import { joinDelegators } from '../../utils'
 import { kiltToFemto } from '../../utils/conversion'
 import { useTxSubmitter } from '../../utils/useTxSubmitter'
+import { BlockchainDataContext } from '../../utils/BlockchainDataContext'
 
 export interface Props {
   staked?: boolean
-  accounts: Account[]
   collator: string
 }
 
-export const NewStakeRow: React.FC<Props> = ({
-  staked = false,
-  accounts,
-  collator,
-}) => {
+export const NewStakeRow: React.FC<Props> = ({ staked = false, collator }) => {
+  const { accounts } = useContext(BlockchainDataContext)
   const { isVisible, showModal, hideModal } = useModal()
   const [newStake, setNewStake] = useState<number | undefined>()
   const [address, setAddress] = useState('')

--- a/src/components/Onboarding/Onboarding.tsx
+++ b/src/components/Onboarding/Onboarding.tsx
@@ -13,6 +13,7 @@ import { NoTokens } from './NoTokens'
 import { NotAcceptedTerms } from './NotAcceptedTerms'
 import { Icon } from '../Icon/Icon'
 import { Button } from '../Button/Button'
+import { BlockchainDataContext } from '../../utils/BlockchainDataContext'
 
 const backgrounds = [bg1, bg2, bg3, bg4]
 
@@ -101,15 +102,10 @@ const DownloadLinks: React.FC = () => {
 }
 
 export interface Props {
-  accounts: Account[]
   extensions: Extension[]
 }
-export const Onboarding: React.FC<Props> = ({
-  accounts,
-  extensions,
-  children,
-}) => {
-  // Get state and corresponding text
+export const Onboarding: React.FC<Props> = ({ extensions, children }) => {
+  const { accounts } = useContext(BlockchainDataContext)
 
   const [background, setBackground] = useState<string | null>(null)
 

--- a/src/components/StakeRow/StakeRow.tsx
+++ b/src/components/StakeRow/StakeRow.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useContext, useState } from 'react'
 import cx from 'classnames'
 import rowStyles from '../../styles/row.module.css'
 import {
@@ -16,22 +16,19 @@ import { StakeModal } from '../StakeModal/StakeModal'
 import { kiltToFemto } from '../../utils/conversion'
 import { useTxSubmitter } from '../../utils/useTxSubmitter'
 import { UnstakeRow } from '../UnstakeRow/UnstakeRow'
+import { BlockchainDataContext } from '../../utils/BlockchainDataContext'
 
 export interface Props {
   stakeInfo: DataStake
-  accounts: Account[]
   collator: string
 }
 
-export const StakeRow: React.FC<Props> = ({
-  stakeInfo,
-  accounts,
-  collator,
-}) => {
+export const StakeRow: React.FC<Props> = ({ stakeInfo, collator }) => {
   const { isVisible, showModal, hideModal } = useModal()
   const [editStake, setEditStake] = useState(false)
   const [newStake, setNewStake] = useState<number | undefined>()
   const signAndSubmitTx = useTxSubmitter()
+  const { accounts } = useContext(BlockchainDataContext)
 
   const handleEdit = () => {
     setEditStake(!editStake)

--- a/src/container/BlockchainData/BlockchainData.tsx
+++ b/src/container/BlockchainData/BlockchainData.tsx
@@ -1,16 +1,18 @@
-import { useContext, useEffect, useState } from 'react'
-import { Account, Candidate, ChainTypes, Data } from '../types'
-import { femtoToKilt } from './conversion'
-import { AccountInfo, initialize } from './polling'
-import { StoredStateContext } from './StoredStateContext'
+import React, { useContext, useEffect, useState } from 'react'
+import { Account, Candidate, ChainTypes, Data } from '../../types'
+import { BlockchainDataContext } from '../../utils/BlockchainDataContext'
+import { femtoToKilt } from '../../utils/conversion'
+import { AccountInfo, initialize } from '../../utils/polling'
+import { StoredStateContext } from '../../utils/StoredStateContext'
 
-export type useBlockchainDataParams = {
+export interface Props {
   partialAccounts: Pick<Account, 'address' | 'name'>[]
 }
 
-export const useBlockchainData = (
-  partialAccounts: Pick<Account, 'address' | 'name'>[]
-) => {
+export const BlockchainData: React.FC<Props> = ({
+  partialAccounts,
+  children,
+}) => {
   const [candidates, setCandidates] = useState<Record<string, Candidate>>({})
   const [selectedCandidates, setSelectedCandidates] = useState<string[]>([])
   const [currentCandidates, setCurrentCandidates] = useState<string[]>([])
@@ -117,5 +119,11 @@ export const useBlockchainData = (
     setAccounts(completeAccounts)
   }, [partialAccounts, accountInfos])
 
-  return { dataSet, accounts, sessionInfo, bestBlock, bestFinalisedBlock }
+  return (
+    <BlockchainDataContext.Provider
+      value={{ dataSet, accounts, sessionInfo, bestBlock, bestFinalisedBlock }}
+    >
+      {children}
+    </BlockchainDataContext.Provider>
+  )
 }

--- a/src/container/IdentityView/IdentityView.tsx
+++ b/src/container/IdentityView/IdentityView.tsx
@@ -8,18 +8,14 @@ import cx from 'classnames'
 import { withdrawStake } from '../../utils/chain'
 import { femtoToKilt } from '../../utils/conversion'
 import { padTime, blockToTime } from '../../utils/timeConvert'
-import { ChainTypes } from '../../types'
 import { format } from '../../utils/index'
 import { useTxSubmitter } from '../../utils/useTxSubmitter'
 import { getPercent } from '../../utils/stakePercentage'
+import { BlockchainDataContext } from '../../utils/BlockchainDataContext'
 
-export interface Props {
-  bestBlock?: ChainTypes.BlockNumber
-}
-
-export const IdentityView: React.FC<Props> = ({ bestBlock }) => {
+export const IdentityView: React.FC = () => {
+  const { bestBlock } = useContext(BlockchainDataContext)
   const [readyToWithdraw, setReadyToWithdraw] = useState(0)
-  // placeholder
   const {
     state: { account },
     dispatch,

--- a/src/container/Page/Page.tsx
+++ b/src/container/Page/Page.tsx
@@ -4,7 +4,7 @@ import { CollatorList } from '../../components/CollatorList/CollatorList'
 import { Header } from '../../components/Header/Header'
 import { ChainInfo } from '../../components/ChainInfo/ChainInfo'
 import styles from './Page.module.css'
-import { useBlockchainData } from '../../utils/useBlockchainData'
+import { BlockchainData } from '../BlockchainData/BlockchainData'
 import { useExtension } from '../../utils/useExtension'
 import { ErrorNotification } from '../ErrorNotification/ErrorNotification'
 import { useConnect } from '../../utils/useConnect'
@@ -16,27 +16,14 @@ export interface Props {}
 export const Page: React.FC<Props> = () => {
   useConnect()
   const { allAccounts, extensions } = useExtension()
-  const {
-    dataSet,
-    accounts,
-    sessionInfo,
-    bestBlock,
-    bestFinalisedBlock,
-  } = useBlockchainData(allAccounts)
   return (
     <div className={styles.page}>
       <Header />
-      <ChainInfo
-        sessionInfo={sessionInfo}
-        bestBlock={bestBlock}
-        bestFinalisedBlock={bestFinalisedBlock}
-      />
-      <Dashboard
-        accounts={accounts}
-        bestBlock={bestBlock}
-        extensions={extensions}
-      />
-      <CollatorList dataSet={dataSet} accounts={accounts} />
+      <BlockchainData partialAccounts={allAccounts}>
+        <ChainInfo />
+        <Dashboard extensions={extensions} />
+        <CollatorList />
+      </BlockchainData>
       <ErrorNotification />
       <ConnectionNotification />
       <BlockchainNotication />

--- a/src/utils/BlockchainDataContext.ts
+++ b/src/utils/BlockchainDataContext.ts
@@ -1,0 +1,13 @@
+import React from 'react'
+import { Data, Account, ChainTypes } from '../types'
+
+export const BlockchainDataContext = React.createContext<{
+  dataSet: Data[]
+  accounts: Account[]
+  sessionInfo?: ChainTypes.RoundInfo
+  bestBlock?: ChainTypes.BlockNumber
+  bestFinalisedBlock?: ChainTypes.BlockNumber
+}>({
+  dataSet: [],
+  accounts: [],
+})


### PR DESCRIPTION
## fixes KILTProtocol/ticket#1608
This PR converts the `useBlockchainData` custom hook to a context giving container component, so that we don't have to drill down the blockchain data through props.
All the blockchain data is now passed via context to the components needing it.

## How to test:
- Test all the functionality

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
