### PR TITLE
fix: sort dsc with same total stake

### DIFF
--- a/src/components/CollatorList/CollatorList.stories.tsx
+++ b/src/components/CollatorList/CollatorList.stories.tsx
@@ -101,7 +101,7 @@ const Template: Story = (args) => (
           active: true,
           activeNext: true,
           isLeaving: false,
-          totalStake: 150_000,
+          totalStake: 100_000,
           delegators: 1,
           lowestStake: 50_000,
           stakes: [],

--- a/src/components/CollatorList/CollatorList.tsx
+++ b/src/components/CollatorList/CollatorList.tsx
@@ -6,6 +6,7 @@ import { CollatorListItem } from '../CollatorListItem/CollatorListItem'
 import { Icon } from '../Icon/Icon'
 import { Input } from '../Input/Input'
 import { BlockchainDataContext } from '../../utils/BlockchainDataContext'
+import { DataWithRank } from '../../types'
 
 enum SORT_BY {
   Rank,
@@ -26,40 +27,38 @@ export const CollatorList: React.FC = () => {
   const [search, setSearch] = useState('')
   const [sortBy, setSortBy] = useState(SORT_BY.Rank)
 
-  const [ranks, setRanks] = useState(new Map<string, number>())
-  const [data, setData] = useState(dataSet)
+  const [dataWithRanks, setDataWithRanks] = useState<DataWithRank[]>([])
+  const [data, setData] = useState<DataWithRank[]>([])
 
   useEffect(() => {
-    let ranks = new Map<string, number>()
-
     const sortedData = [...dataSet]
     sortedData.sort((a, b) => b.totalStake - a.totalStake)
 
-    sortedData.forEach((value, index) => {
-      ranks.set(value.collator, index + 1)
+    const dataWithRanks: DataWithRank[] = sortedData.map((value, index) => {
+      return { ...value, rank: index + 1 }
     })
 
-    setRanks(ranks)
+    setDataWithRanks(dataWithRanks)
   }, [dataSet])
 
   useEffect(() => {
     let newData = !search.length
-      ? [...dataSet]
-      : dataSet.filter((value) => value.collator.startsWith(search))
+      ? [...dataWithRanks]
+      : dataWithRanks.filter((value) => value.collator.startsWith(search))
 
     switch (sortBy) {
       case SORT_BY.Rank_Reverse: {
-        newData.sort((a, b) => a.totalStake - b.totalStake)
+        newData.sort((a, b) => a.rank - b.rank)
         break
       }
       default:
       case SORT_BY.Rank: {
-        newData.sort((a, b) => b.totalStake - a.totalStake)
+        newData.sort((a, b) => b.rank - a.rank)
         break
       }
     }
     setData(newData)
-  }, [search, dataSet, sortBy])
+  }, [search, dataSet, sortBy, dataWithRanks])
 
   return (
     <table role="table" className={styles.table}>
@@ -142,11 +141,7 @@ export const CollatorList: React.FC = () => {
       </thead>
       <tbody className={styles.tableBody}>
         {data.map((entry) => (
-          <CollatorListItem
-            entry={entry}
-            rank={ranks.get(entry.collator)}
-            key={entry.collator}
-          />
+          <CollatorListItem entry={entry} key={entry.collator} />
         ))}
       </tbody>
     </table>

--- a/src/components/CollatorListItem/CollatorListItem.tsx
+++ b/src/components/CollatorListItem/CollatorListItem.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useState } from 'react'
-import { Data } from '../../types'
+import { DataWithRank } from '../../types'
 import styles from './CollatorListItem.module.css'
 import rowStyles from '../../styles/row.module.css'
 import { StakeRow } from '../StakeRow/StakeRow'
@@ -8,13 +8,12 @@ import { CollatorRow } from '../CollatorRow/CollatorRow'
 import { StoredStateContext } from '../../utils/StoredStateContext'
 
 export interface Props {
-  entry: Data
-  rank: number | undefined
+  entry: DataWithRank
 }
 
 const COLS = 7
 
-export const CollatorListItem: React.FC<Props> = ({ entry, rank }) => {
+export const CollatorListItem: React.FC<Props> = ({ entry }) => {
   const [expanded, setExpanded] = useState(false)
   const {
     state: { termsAccepted },
@@ -24,7 +23,6 @@ export const CollatorListItem: React.FC<Props> = ({ entry, rank }) => {
       <tr className={styles.firstRow}></tr>
       <CollatorRow
         entry={entry}
-        rank={rank}
         expanded={expanded}
         setExpanded={setExpanded}
       />

--- a/src/components/CollatorRow/CollatorRow.tsx
+++ b/src/components/CollatorRow/CollatorRow.tsx
@@ -5,21 +5,19 @@ import { Button } from '../Button/Button'
 import { Icon } from '../Icon/Icon'
 import rowStyles from '../../styles/row.module.css'
 import { format, leftFillZero } from '../../utils'
-import { Data } from '../../types'
+import { DataWithRank } from '../../types'
 import { StoredStateContext } from '../../utils/StoredStateContext'
 
 // TODO: Max candidates will be changed at a later date. Smaller now for testing purposes.
 const MAX_SELECTED_CANDIDATES = 16
 export interface Props {
-  entry: Data
-  rank: number | undefined
+  entry: DataWithRank
   setExpanded: (expanded: boolean) => void
   expanded: boolean
 }
 
 export const CollatorRow: React.FC<Props> = ({
   entry,
-  rank,
   setExpanded,
   expanded,
 }) => {
@@ -80,11 +78,13 @@ export const CollatorRow: React.FC<Props> = ({
       <td>
         <span
           className={cx({
-            [rowStyles.topRank]: rank && rank <= MAX_SELECTED_CANDIDATES,
-            [rowStyles.candidatePool]: rank && rank > MAX_SELECTED_CANDIDATES,
+            [rowStyles.topRank]:
+              entry.rank && entry.rank <= MAX_SELECTED_CANDIDATES,
+            [rowStyles.candidatePool]:
+              entry.rank && entry.rank > MAX_SELECTED_CANDIDATES,
           })}
         >
-          {leftFillZero(rank, 3)}
+          {leftFillZero(entry.rank, 3)}
         </span>
         {format(entry.totalStake)}
       </td>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -24,6 +24,10 @@ export interface Data {
   favorite: boolean
 }
 
+export interface DataWithRank extends Data {
+  rank: number
+}
+
 export interface Account {
   address: string
   name?: string


### PR DESCRIPTION
## fixes KILTProtocol/ticket#1613
Fixes the wrong DSC sorting, when collator have the same total stake (should be also mitigated, when people  start to stake as delegators...)

## How to test:
- Sort by rank dsc

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
