### PR TITLE
fix: wrong address in stake modal

### DIFF
--- a/src/components/NewStakeRow/NewStakeRow.tsx
+++ b/src/components/NewStakeRow/NewStakeRow.tsx
@@ -83,11 +83,8 @@ export const NewStakeRow: React.FC<Props> = ({ staked = false, collator }) => {
       <td>
         {account && isVisible && newStake !== undefined && newStake >= 0 && (
           <StakeModal
-            modalStake={{
-              name: account.name,
-              address: account.address,
-              newStake,
-            }}
+            collatorAddress={collator}
+            newStake={newStake}
             status={getStatus(newStake, account.staked)}
             closeModal={hideModal}
             onConfirm={handleDelegatorStake}

--- a/src/components/StakeModal/StakeModal.stories.tsx
+++ b/src/components/StakeModal/StakeModal.stories.tsx
@@ -13,10 +13,7 @@ const Template: Story<Props> = ({ ...args }) => {
 
 export const Primary = Template.bind({})
 Primary.args = {
-  modalStake: {
-    name: 'KILT Identity 1',
-    address: '56713563215473164',
-    newStake: 123,
-  },
+  collatorAddress: '56713563215473164',
+  newStake: 123,
   status: 'increaseStake',
 }

--- a/src/components/StakeModal/StakeModal.tsx
+++ b/src/components/StakeModal/StakeModal.tsx
@@ -1,22 +1,23 @@
-import { ModalStake } from '../../types'
 import { Button } from '../Button/Button'
 import { shortenAddress } from '../../utils/shortenAddress'
 import { Modal } from '../Modal/Modal'
 
 export interface Props {
-  modalStake: ModalStake
+  collatorAddress: string
+  newStake: number
   onConfirm: () => void
   closeModal: () => void
   status: 'increaseStake' | 'decreaseStake' | 'unstake' | 'unchanged' | 'stake'
 }
 
 export const StakeModal: React.FC<Props> = ({
-  modalStake,
+  collatorAddress,
+  newStake,
   onConfirm,
   closeModal,
   status,
 }) => {
-  const shortAddress = shortenAddress(modalStake.address)
+  const shortAddress = shortenAddress(collatorAddress)
 
   const NOTES_MESSAGE = (
     <p>
@@ -44,7 +45,7 @@ export const StakeModal: React.FC<Props> = ({
           Do you want to stake on <br />
           Collator {shortAddress}? <br />
           <br />
-          STAKE: {modalStake.newStake.toLocaleString()} <br />
+          STAKE: {newStake.toLocaleString()} <br />
         </Modal>
       )
     case 'increaseStake':
@@ -61,7 +62,7 @@ export const StakeModal: React.FC<Props> = ({
           Do you want to increase stake on <br />
           Collator {shortAddress}? <br />
           <br />
-          STAKE: {modalStake.newStake.toLocaleString()} <br />
+          STAKE: {newStake.toLocaleString()} <br />
         </Modal>
       )
     case 'decreaseStake':
@@ -79,7 +80,7 @@ export const StakeModal: React.FC<Props> = ({
             Do you want to decrease the stake of <br />
             Collator {shortAddress} <br />
             <br />
-            STAKE: {modalStake.newStake.toLocaleString()} <br />
+            STAKE: {newStake.toLocaleString()} <br />
           </div>
           {NOTES_MESSAGE}
         </Modal>

--- a/src/components/StakeRow/StakeRow.tsx
+++ b/src/components/StakeRow/StakeRow.tsx
@@ -133,12 +133,8 @@ export const StakeRow: React.FC<Props> = ({ stakeInfo, collator }) => {
       {editStake && <UnstakeRow handleUnstake={handleUnstake} />}
       {editStake && isVisible && newStake !== undefined && (
         <StakeModal
-          modalStake={{
-            name: account.name,
-            address: account.address,
-            newStake,
-            staked: stakeInfo.stake,
-          }}
+          collatorAddress={collator}
+          newStake={newStake}
           status={getStatus(newStake, stakeInfo.stake)}
           closeModal={hideModal}
           onConfirm={handleStake}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -51,13 +51,6 @@ export interface Candidate {
   userStakes: Array<Stake>
 }
 
-export interface ModalStake {
-  name: string | undefined
-  address: string
-  newStake: number
-  staked?: number
-}
-
 export interface Extension {
   name: string
   version: string


### PR DESCRIPTION
## fixes KILTProtocol/ticket#1611
The stake modal was displaying the user account address and not the one  from the collator.

## How to test:
- Open the stakemodal with the new stake row or edit mode

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
