### PR TITLE
fix: closing search should reset search

### DIFF
--- a/src/components/CollatorList/CollatorList.tsx
+++ b/src/components/CollatorList/CollatorList.tsx
@@ -75,6 +75,7 @@ export const CollatorList: React.FC = () => {
               className={styles.searchButton}
               onClick={(e) => {
                 e.stopPropagation()
+                setSearch('')
                 setShowSearch(!showSearch)
               }}
             >


### PR DESCRIPTION
## fixes KILTProtocol/ticket#1610
This PR resets the search string when closing the search bar

## How to test:
- open search
- type a string
- close search

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
