### PR TITLE
fix: wrong default sorting

### DIFF
--- a/src/components/CollatorList/CollatorList.tsx
+++ b/src/components/CollatorList/CollatorList.tsx
@@ -48,12 +48,12 @@ export const CollatorList: React.FC = () => {
 
     switch (sortBy) {
       case SORT_BY.Rank_Reverse: {
-        newData.sort((a, b) => a.rank - b.rank)
+        newData.sort((a, b) => b.rank - a.rank)
         break
       }
       default:
       case SORT_BY.Rank: {
-        newData.sort((a, b) => b.rank - a.rank)
+        newData.sort((a, b) => a.rank - b.rank)
         break
       }
     }


### PR DESCRIPTION
## No-Ticket
This PR sorts the collators correctly per default. It was ascending by rank, but it should be descending.

## How to test:
- Open a fresh instance of the stakeboard

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/principles/boy-scout-rule)
- [ ] I have documented the changes (where applicable)
