### PR TITLE
feat: add link to w3n.id for w3ns

### DIFF
--- a/src/components/Collator/Collator.tsx
+++ b/src/components/Collator/Collator.tsx
@@ -5,6 +5,7 @@ import { Identicon } from '../Identicon/Identicon'
 import styles from './Collator.module.css'
 import { shortenAddress } from '../../utils/shortenAddress'
 import { getConnection } from '../../utils/useConnect'
+import { Web3Name } from '../Web3Name/Web3Name'
 
 export interface Props {
   address: string
@@ -48,7 +49,7 @@ export const Collator: React.FC<Props> = ({ address, activeSince }) => {
       </span>
       <div className={styles.wrapper}>
         <span title={address} className={styles.address}>
-          {web3name || shortAddress}
+          {web3name ? <Web3Name name={web3name} /> : shortAddress}
         </span>
       </div>
     </>

--- a/src/components/Web3Name/Web3Name.module.css
+++ b/src/components/Web3Name/Web3Name.module.css
@@ -1,0 +1,4 @@
+.yellow {
+  color: var(--color-primary);
+  text-decoration: none;
+}

--- a/src/components/Web3Name/Web3Name.tsx
+++ b/src/components/Web3Name/Web3Name.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import styles from './Web3Name.module.css'
+
+const W3N_URL = process.env.W3N_URL || 'https://w3n.id/'
+const W3N_PREFIX = process.env.W3N_PREFIX || 'w3n:'
+
+export interface Props {
+  name: string
+}
+
+export const Web3Name: React.FC<Props> = ({ name }) => {
+  return (
+    <>
+      <a
+        className={styles.yellow}
+        href={W3N_URL + name}
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        {W3N_PREFIX + name}
+      </a>
+    </>
+  )
+}

--- a/src/components/Web3Name/Web3Name.tsx
+++ b/src/components/Web3Name/Web3Name.tsx
@@ -10,15 +10,13 @@ export interface Props {
 
 export const Web3Name: React.FC<Props> = ({ name }) => {
   return (
-    <>
-      <a
-        className={styles.yellow}
-        href={W3N_URL + name}
-        rel="noopener noreferrer"
-        target="_blank"
-      >
-        {W3N_PREFIX + name}
-      </a>
-    </>
+    <a
+      className={styles.yellow}
+      href={W3N_URL + name}
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      {W3N_PREFIX + name}
+    </a>
   )
 }


### PR DESCRIPTION
Create links out of w3ns on stakeboard.
Users can find out more about collators that way. Also collators that have a w3n are highlighted. So it is an incentive to actually link a w3n.

![Screenshot 2022-07-28 at 11 16 01](https://user-images.githubusercontent.com/14820950/181469396-d27f0172-b924-4ee5-bd95-4590186d065a.png)
