### PR TITLE
feat: copy collator address

### DIFF
--- a/src/components/Identicon/Identicon.module.css
+++ b/src/components/Identicon/Identicon.module.css
@@ -2,4 +2,5 @@
   position: relative;
   display: inline-block;
   vertical-align: middle;
+  cursor: copy;
 }

--- a/src/components/Identicon/Identicon.tsx
+++ b/src/components/Identicon/Identicon.tsx
@@ -1,17 +1,42 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { polkadotIcon } from '@polkadot/ui-shared'
 
 import styles from './Identicon.module.css'
 
-interface CircleProps {
-  cx: number
-  cy: number
-  fill: string
-  r: number
+interface AddressIconProps {
+  address: string
+  size: number
 }
 
-const Circle: React.FC<CircleProps> = ({ cx, cy, fill, r }) => {
-  return <circle cx={cx} cy={cy} fill={fill} r={r} />
+const AddressIcon: React.FC<AddressIconProps> = ({ address, size }) => {
+  const circles = polkadotIcon(address, { isAlternative: false })
+
+  return (
+    <svg width={size} height={size} viewBox="0 0 64 64">
+      {circles.map((circle) => (
+        <circle cx={circle.cx} cy={circle.cy} fill={circle.fill} r={circle.r} />
+      ))}
+    </svg>
+  )
+}
+
+interface CheckmarkIconProps {
+  fill: string
+  size: number
+}
+
+const CheckmarkIcon: React.FC<CheckmarkIconProps> = ({ fill, size }) => {
+  return (
+    <svg width={size} height={size} viewBox="0 0 500 500">
+      <g>
+        <path
+          fill={fill}
+          d="M418.275,418.275c95.7-95.7,95.7-250.8,0-346.5s-250.8-95.7-346.5,0s-95.7,250.8,0,346.5S322.675,513.975,418.275,418.275
+			z M157.175,207.575l55.1,55.1l120.7-120.6l42.7,42.7l-120.6,120.6l-42.8,42.7l-42.7-42.7l-55.1-55.1L157.175,207.575z"
+        />
+      </g>
+    </svg>
+  )
 }
 
 export interface Props {
@@ -20,21 +45,30 @@ export interface Props {
 }
 
 export const Identicon: React.FC<Props> = ({ address, size = 46 }) => {
-  const circles = polkadotIcon(address, { isAlternative: false })
-  // circles[0].fill = '#575756'
+  const [didCopy, setDidCopy] = useState(false)
+
+  function copyAddress() {
+    if (navigator.clipboard) {
+      navigator.clipboard.writeText(address).then(() => {
+        setDidCopy(true)
+        setTimeout(() => {
+          setDidCopy(false)
+        }, 1500)
+      })
+    }
+  }
+
   return (
-    <div className={styles.Identicon} style={{ width: size, height: size }}>
-      <svg width={size} height={size} viewBox="0 0 64 64">
-        {circles.map((circle, index) => (
-          <Circle
-            cx={circle.cx}
-            cy={circle.cy}
-            fill={circle.fill}
-            r={circle.r}
-            key={index}
-          />
-        ))}
-      </svg>
+    <div
+      className={styles.Identicon}
+      style={{ width: size, height: size }}
+      onClick={copyAddress}
+    >
+      {didCopy ? (
+        <CheckmarkIcon size={size} fill='#FFFFFF' />
+      ) : (
+        <AddressIcon size={size} address={address} />
+      )}
     </div>
   )
 }


### PR DESCRIPTION
Let's you copy the collator address by clicking on the identicon as you would expect it.
Even gives a nice green background as a feedback that the copy was successful.

![Screenshot 2022-07-28 at 14 37 01](https://user-images.githubusercontent.com/14820950/181506690-46576d74-0614-4a05-839b-1cb4a9e8585e.png)
