### PR TITLE
fix: fallbacks and randomisation for rpc endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ The Stakeboard requires a connection to the KILT chain.
 
 For testing purposes, the Stakeboard is connected to the KILT test net Peregrine by default. If you wish to use a local chain for testing, you can be connect by making a copy of the `.env.example` and renaming the file to `.env`. Here you can change the `REACT_APP_FULL_NODE_ENDPOINT` to the new endpoint.
 
+`REACT_APP_FULL_NODE_ENDPOINT` also accepts a comma separated list of endpoints, in which case subsequent entries will be treated as fallback if the application fails to connect to the first in line.
+
 Run the following commands to install dependencies and start developing
 
 ```js

--- a/src/utils/useConnect.ts
+++ b/src/utils/useConnect.ts
@@ -8,7 +8,8 @@ let cachedApi: Promise<ApiPromise> | null = null
 let wsProvider: WsProvider | null = null
 
 const ENDPOINT =
-  process.env.REACT_APP_FULL_NODE_ENDPOINT ||
+  // allows comma separated list of endpoints
+  process.env.REACT_APP_FULL_NODE_ENDPOINT?.split(',').map((i) => i.trim()) ||
   'wss://peregrine.kilt.io/parachain-public-ws'
 
 export const useConnect = () => {

--- a/src/utils/useConnect.ts
+++ b/src/utils/useConnect.ts
@@ -12,6 +12,14 @@ const ENDPOINT =
   process.env.REACT_APP_FULL_NODE_ENDPOINT?.split(',').map((i) => i.trim()) ||
   'wss://peregrine.kilt.io/parachain-public-ws'
 
+if (ENDPOINT instanceof Array && process.env.REACT_APP_SHUFFLE_ENDPOINTS) {
+  // shuffle endpoint priority
+  for (let i = ENDPOINT.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    ;[ENDPOINT[i], ENDPOINT[j]] = [ENDPOINT[j], ENDPOINT[i]]
+  }
+}
+
 export const useConnect = () => {
   const { dispatch } = useContext(StateContext)
 

--- a/src/utils/useConnect.ts
+++ b/src/utils/useConnect.ts
@@ -12,7 +12,7 @@ const ENDPOINT =
   process.env.REACT_APP_FULL_NODE_ENDPOINT?.split(',').map((i) => i.trim()) ||
   'wss://peregrine.kilt.io/parachain-public-ws'
 
-if (ENDPOINT instanceof Array && process.env.REACT_APP_SHUFFLE_ENDPOINTS) {
+if (ENDPOINT instanceof Array && process.env.REACT_APP_SHUFFLE_ENDPOINTS === 'true') {
   // shuffle endpoint priority
   for (let i = ENDPOINT.length - 1; i > 0; i--) {
     const j = Math.floor(Math.random() * (i + 1))


### PR DESCRIPTION
With this change, we can pass a list of rpc endpoints in the env configuration which then are taken as fallbacks if stakeboard fails to connect to the first entry. E.g. with a configuration like 
```
REACT_APP_FULL_NODE_ENDPOINT=wss://kilt-rpc.dwellir.com,wss://spiritnet.kilt.io,wss://spiritnet.api.onfinality.io/public-ws
```
stakeboard will first try to connect to dwellir, fail, then connect to spiritnet.kilt.io instead.

Additionally, you can set a config option 
```
REACT_APP_SHUFFLE_ENDPOINTS=true
```
during build which results in stakeboard shuffling the order in which endpoints are tried, acting as a basic form of load balancing.