### PR TITLE
fix: add delay before calling web3Enable

### DIFF
--- a/src/container/Page/Page.tsx
+++ b/src/container/Page/Page.tsx
@@ -18,9 +18,8 @@ import { StateContext } from '../../utils/StateContext'
 export interface Props {}
 
 export const Page: React.FC<Props> = () => {
-  const { state } = useContext(StateContext)
   useConnect()
-  const { allAccounts, extensions } = useExtension(state.termsAccepted)
+  const { allAccounts, extensions } = useExtension()
   if (process.env.REACT_APP_MAINTENANCE === 'true') return <Maintenance />
   return (
     <div className={styles.page}>

--- a/src/container/Page/Page.tsx
+++ b/src/container/Page/Page.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import React from 'react'
 import { Dashboard } from '../../components/Dashboard/Dashboard'
 import { CollatorList } from '../../components/CollatorList/CollatorList'
 import { Header } from '../../components/Header/Header'
@@ -13,7 +13,6 @@ import { LoadingDataNotification } from '../../components/LoadingDataNotificatio
 import { ConnectionNotification } from '../../components/ConnectionNotification/ConnectionNotification'
 import { BlockchainNotication } from '../BlockchainNotification/BlockchainNotification'
 import { Maintenance } from '../Maintenance/Maintenance'
-import { StateContext } from '../../utils/StateContext'
 
 export interface Props {}
 

--- a/src/container/Page/Page.tsx
+++ b/src/container/Page/Page.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useContext } from 'react'
 import { Dashboard } from '../../components/Dashboard/Dashboard'
 import { CollatorList } from '../../components/CollatorList/CollatorList'
 import { Header } from '../../components/Header/Header'
@@ -13,12 +13,14 @@ import { LoadingDataNotification } from '../../components/LoadingDataNotificatio
 import { ConnectionNotification } from '../../components/ConnectionNotification/ConnectionNotification'
 import { BlockchainNotication } from '../BlockchainNotification/BlockchainNotification'
 import { Maintenance } from '../Maintenance/Maintenance'
+import { StateContext } from '../../utils/StateContext'
 
 export interface Props {}
 
 export const Page: React.FC<Props> = () => {
+  const { state } = useContext(StateContext)
   useConnect()
-  const { allAccounts, extensions } = useExtension()
+  const { allAccounts, extensions } = useExtension(state.termsAccepted)
   if (process.env.REACT_APP_MAINTENANCE === 'true') return <Maintenance />
   return (
     <div className={styles.page}>

--- a/src/utils/useExtension.ts
+++ b/src/utils/useExtension.ts
@@ -35,14 +35,16 @@ export const useExtension = () => {
 
   // Enable extensions
   useEffect(() => {
-    async function doEffect() {
-      const allInjected = await web3Enable('Stakeboard')
-      setExtensions(allInjected)
-      setWeb3Enabled(true)
-    }
     // calling web3Enable too quickly after page load could result in extensions not being found.
-    setTimeout(doEffect, 500)
-  }, [])
+    if (document.readyState === 'complete') {
+      // sporran still needs a little more time after 'load'
+      setTimeout(async () => {
+        const allInjected = await web3Enable('Stakeboard')
+        setExtensions(allInjected)
+        setWeb3Enabled(true)
+      }, 200)
+    }
+  }, [document.readyState])
 
   // Get accounts from extensions
   useEffect(() => {

--- a/src/utils/useExtension.ts
+++ b/src/utils/useExtension.ts
@@ -4,23 +4,6 @@ import { web3Accounts, web3Enable } from '@polkadot/extension-dapp'
 import { getGenesis } from './chain'
 import { Account, Extension } from '../types'
 
-/* 
-async function getAllAccounts() {
-  const allInjected = await web3Enable('Stakeboard')
-  console.log('allInjected', allInjected)
-  const allAccounts = await web3Accounts()
-  console.log('allAccounts', allAccounts)
-  const source = allAccounts[0].meta.source
-  console.log('source', source)
-  const injector = await web3FromSource(source)
-  console.log('injector', injector)
-  const rpcProviders = await web3ListRpcProviders(source)
-  console.log('rpcProviders', rpcProviders)
-}
-
-getAllAccounts()
-*/
-
 export const useExtension = (ready: boolean) => {
   const [extensions, setExtensions] = useState<Extension[]>([])
   const [allAccounts, setAllAccounts] = useState<

--- a/src/utils/useExtension.ts
+++ b/src/utils/useExtension.ts
@@ -1,10 +1,15 @@
-import { useEffect, useState } from 'react'
+import { useContext, useEffect, useState } from 'react'
 import { web3Accounts, web3Enable } from '@polkadot/extension-dapp'
 
 import { getGenesis } from './chain'
 import { Account, Extension } from '../types'
+import { StateContext } from './StateContext'
 
-export const useExtension = (ready: boolean) => {
+export const useExtension = () => {
+  const {
+    state: { termsAccepted },
+  } = useContext(StateContext)
+
   const [extensions, setExtensions] = useState<Extension[]>([])
   const [allAccounts, setAllAccounts] = useState<
     Pick<Account, 'address' | 'name'>[]
@@ -18,10 +23,10 @@ export const useExtension = (ready: boolean) => {
         setExtensions(allInjected)
       }
     }
-    if (ready) {
+    if (termsAccepted) {
       enable()
     }
-  }, [ready])
+  }, [termsAccepted])
 
   // Get accounts from extensions
   useEffect(() => {

--- a/src/utils/useExtension.ts
+++ b/src/utils/useExtension.ts
@@ -1,9 +1,5 @@
 import { useEffect, useState } from 'react'
-import {
-  isWeb3Injected,
-  web3Accounts,
-  web3Enable,
-} from '@polkadot/extension-dapp'
+import { web3Accounts, web3Enable } from '@polkadot/extension-dapp'
 
 import { getGenesis } from './chain'
 import { Account, Extension } from '../types'
@@ -20,13 +16,12 @@ async function getAllAccounts() {
   console.log('injector', injector)
   const rpcProviders = await web3ListRpcProviders(source)
   console.log('rpcProviders', rpcProviders)
-} 
+}
 
 getAllAccounts()
 */
 
 export const useExtension = (ready: boolean) => {
-  const [web3Enabled, setWeb3Enabled] = useState(false)
   const [extensions, setExtensions] = useState<Extension[]>([])
   const [allAccounts, setAllAccounts] = useState<
     Pick<Account, 'address' | 'name'>[]
@@ -38,7 +33,6 @@ export const useExtension = (ready: boolean) => {
       const allInjected = await web3Enable('Stakeboard')
       if (allInjected.length) {
         setExtensions(allInjected)
-        setWeb3Enabled(isWeb3Injected)
       }
     }
     if (ready) {
@@ -49,7 +43,7 @@ export const useExtension = (ready: boolean) => {
   // Get accounts from extensions
   useEffect(() => {
     async function doEffect() {
-      if (web3Enabled) {
+      if (extensions.length) {
         const allAccounts = await web3Accounts()
         // TODO: We want to filter the account for the ones usable with the connected chain
         const genesisHash = await getGenesis()
@@ -68,7 +62,7 @@ export const useExtension = (ready: boolean) => {
       }
     }
     doEffect()
-  }, [web3Enabled])
+  }, [extensions])
 
   return { allAccounts, extensions }
 }

--- a/src/utils/useExtension.ts
+++ b/src/utils/useExtension.ts
@@ -40,7 +40,8 @@ export const useExtension = () => {
       setExtensions(allInjected)
       setWeb3Enabled(true)
     }
-    doEffect()
+    // calling web3Enable too quickly after page load could result in extensions not being found.
+    setTimeout(doEffect, 500)
   }, [])
 
   // Get accounts from extensions

--- a/src/utils/useExtension.ts
+++ b/src/utils/useExtension.ts
@@ -3,13 +3,12 @@ import {
   isWeb3Injected,
   web3Accounts,
   web3Enable,
-  web3FromSource,
-  web3ListRpcProviders,
 } from '@polkadot/extension-dapp'
 
 import { getGenesis } from './chain'
 import { Account, Extension } from '../types'
 
+/* 
 async function getAllAccounts() {
   const allInjected = await web3Enable('Stakeboard')
   console.log('allInjected', allInjected)
@@ -21,9 +20,10 @@ async function getAllAccounts() {
   console.log('injector', injector)
   const rpcProviders = await web3ListRpcProviders(source)
   console.log('rpcProviders', rpcProviders)
-}
+} 
 
-// getAllAccounts()
+getAllAccounts()
+*/
 
 export const useExtension = (ready: boolean) => {
   const [web3Enabled, setWeb3Enabled] = useState(false)

--- a/src/utils/useExtension.ts
+++ b/src/utils/useExtension.ts
@@ -1,11 +1,10 @@
 import { useEffect, useState } from 'react'
 import {
+  isWeb3Injected,
   web3Accounts,
   web3Enable,
-  web3FromAddress,
   web3FromSource,
   web3ListRpcProviders,
-  web3UseRpcProvider,
 } from '@polkadot/extension-dapp'
 
 import { getGenesis } from './chain'
@@ -26,7 +25,7 @@ async function getAllAccounts() {
 
 // getAllAccounts()
 
-export const useExtension = () => {
+export const useExtension = (ready: boolean) => {
   const [web3Enabled, setWeb3Enabled] = useState(false)
   const [extensions, setExtensions] = useState<Extension[]>([])
   const [allAccounts, setAllAccounts] = useState<
@@ -35,16 +34,17 @@ export const useExtension = () => {
 
   // Enable extensions
   useEffect(() => {
-    // calling web3Enable too quickly after page load could result in extensions not being found.
-    if (document.readyState === 'complete') {
-      // sporran still needs a little more time after 'load'
-      setTimeout(async () => {
-        const allInjected = await web3Enable('Stakeboard')
+    async function enable() {
+      const allInjected = await web3Enable('Stakeboard')
+      if (allInjected.length) {
         setExtensions(allInjected)
-        setWeb3Enabled(true)
-      }, 200)
+        setWeb3Enabled(isWeb3Injected)
+      }
     }
-  }, [document.readyState])
+    if (ready) {
+      enable()
+    }
+  }, [ready])
 
   // Get accounts from extensions
   useEffect(() => {

--- a/src/utils/useExtension.ts
+++ b/src/utils/useExtension.ts
@@ -23,6 +23,8 @@ export const useExtension = () => {
         setExtensions(allInjected)
       }
     }
+    // wait for blockchain data to be loaded - this gives extensions time to inject.
+    // Loading extensions immediately on page load results in sporran sometimes not being found by stakeboard.
     if (loadingData === 'available') {
       enable()
     }

--- a/src/utils/useExtension.ts
+++ b/src/utils/useExtension.ts
@@ -7,7 +7,7 @@ import { StateContext } from './StateContext'
 
 export const useExtension = () => {
   const {
-    state: { termsAccepted },
+    state: { loadingData },
   } = useContext(StateContext)
 
   const [extensions, setExtensions] = useState<Extension[]>([])
@@ -23,10 +23,10 @@ export const useExtension = () => {
         setExtensions(allInjected)
       }
     }
-    if (termsAccepted) {
+    if (loadingData === 'available') {
       enable()
     }
-  }, [termsAccepted])
+  }, [loadingData])
 
   // Get accounts from extensions
   useEffect(() => {


### PR DESCRIPTION
Enable extensions only after the user accepted the terms of use which provides a natural delay allowing for extensions to inject into the page.
Also makes sure we don't process anything use related on the page until they accepted the terms, if that matters at all.