### PR TITLE
fix: dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "@kiltprotocol/augment-api": "^0.30.0",
     "@kiltprotocol/type-definitions": "^0.30.0",
     "@polkadot/api": "^9.6.2",
-    "@polkadot/api-augment": "^9.6.2",
     "@polkadot/extension-dapp": "^0.44.6",
     "@polkadot/types": "^9.6.2",
     "@polkadot/ui-shared": "^2.9.8",

--- a/package.json
+++ b/package.json
@@ -71,8 +71,5 @@
     "@storybook/preset-create-react-app": "^3.1.7",
     "@storybook/react": "^6.2.9",
     "@types/react-select": "^4.0.16"
-  },
-  "resolutions": {
-    "babel-loader": "8.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "license": "BSD-4-Clause",
   "dependencies": {
-    "@kiltprotocol/augment-api": "^0.30.0-rc.1",
-    "@kiltprotocol/type-definitions": "^0.30.0-rc.1",
+    "@kiltprotocol/augment-api": "^0.30.0",
+    "@kiltprotocol/type-definitions": "^0.30.0",
     "@polkadot/api": "^9.6.2",
     "@polkadot/api-augment": "^9.6.2",
     "@polkadot/extension-dapp": "^0.44.6",

--- a/src/components/Collator/Collator.tsx
+++ b/src/components/Collator/Collator.tsx
@@ -16,14 +16,12 @@ export const Collator: React.FC<Props> = ({ address }) => {
   useEffect(() => {
     const getWeb3name = async () => {
       const api = await getConnection()
-      const connectedDid = await api.query.didLookup.connectedDids(address)
+      const connectedDid = await api.call.did.queryByAccount(address)
       if (connectedDid.isSome) {
-        const unwrapped = connectedDid.unwrap()
-        const didAccount = unwrapped.did.toString()
-        const web3name = await api.query.web3Names.names(didAccount)
+        const web3name = connectedDid.unwrap().w3n
         if (web3name.isSome) {
           const unwrapped = web3name.unwrap()
-          setWeb3name(unwrapped.toUtf8())
+          setWeb3name(unwrapped.toString())
         }
       }
     }

--- a/src/components/Collator/Collator.tsx
+++ b/src/components/Collator/Collator.tsx
@@ -1,6 +1,4 @@
 import React, { useEffect, useState } from 'react'
-import { Option, Bytes, Struct } from '@polkadot/types'
-import { AccountId } from '@polkadot/types/interfaces'
 import { Identicon } from '../Identicon/Identicon'
 import styles from './Collator.module.css'
 import { shortenAddress } from '../../utils/shortenAddress'
@@ -12,25 +10,17 @@ export interface Props {
   activeSince?: number
 }
 
-interface PalletDidLookupConnectionRecord extends Struct {
-  did: AccountId
-}
-
-export const Collator: React.FC<Props> = ({ address, activeSince }) => {
+export const Collator: React.FC<Props> = ({ address }) => {
   const [web3name, setWeb3name] = useState<string | null>(null)
 
   useEffect(() => {
     const getWeb3name = async () => {
       const api = await getConnection()
-      const connectedDid = await api.query.didLookup.connectedDids<
-        Option<PalletDidLookupConnectionRecord>
-      >(address)
+      const connectedDid = await api.query.didLookup.connectedDids(address)
       if (connectedDid.isSome) {
         const unwrapped = connectedDid.unwrap()
         const didAccount = unwrapped.did.toString()
-        const web3name = await api.query.web3Names.names<Option<Bytes>>(
-          didAccount
-        )
+        const web3name = await api.query.web3Names.names(didAccount)
         if (web3name.isSome) {
           const unwrapped = web3name.unwrap()
           setWeb3name(unwrapped.toUtf8())

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import '@polkadot/api-augment'
+import '@kiltprotocol/augment-api'
 import './index.css'
 import App from './App'
 import reportWebVitals from './reportWebVitals'

--- a/src/types/chainTypes.ts
+++ b/src/types/chainTypes.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   ParachainStakingCandidate,
   ParachainStakingCandidateStatus,
   ParachainStakingRoundInfo,

--- a/src/types/chainTypes.ts
+++ b/src/types/chainTypes.ts
@@ -5,9 +5,7 @@ import type {
   ParachainStakingStake,
   ParachainStakingTotalStake,
 } from '@kiltprotocol/augment-api'
-import type {
-  BlockNumber,
-} from '@polkadot/types/interfaces'
+import type { BlockNumber } from '@polkadot/types/interfaces'
 export type { BlockNumber }
 
 export type Stake = ParachainStakingStake

--- a/src/types/chainTypes.ts
+++ b/src/types/chainTypes.ts
@@ -1,43 +1,21 @@
-import type { Struct, Vec, Enum, Null } from '@polkadot/types'
+import {
+  ParachainStakingCandidate,
+  ParachainStakingCandidateStatus,
+  ParachainStakingRoundInfo,
+  ParachainStakingStake,
+  ParachainStakingTotalStake,
+} from '@kiltprotocol/augment-api'
 import type {
-  AccountId,
-  Balance,
-  SessionIndex,
   BlockNumber,
 } from '@polkadot/types/interfaces'
 export type { BlockNumber }
 
-export interface Stake extends Struct {
-  owner: AccountId
-  amount: Balance
-}
+export type Stake = ParachainStakingStake
 
-export interface CollatorStatus extends Enum {
-  asActive: Null
-  asLeaving: SessionIndex
-  isActive: boolean
-  isLeaving: boolean
-}
-export interface Collator extends Struct {
-  id: AccountId
-  stake: Balance
-  delegators: Vec<Stake>
-  total: Balance
-  status: CollatorStatus
-}
+export type CollatorStatus = ParachainStakingCandidateStatus
 
-export interface RoundInfo extends Struct {
-  current: SessionIndex
-  first: BlockNumber
-  length: BlockNumber
-}
+export type Collator = ParachainStakingCandidate
 
-export interface Delegator extends Struct {
-  owner: AccountId
-  amount: Balance
-}
+export type RoundInfo = ParachainStakingRoundInfo
 
-export interface TotalStake extends Struct {
-  collators: Balance
-  delegators: Balance
-}
+export type TotalStake = ParachainStakingTotalStake

--- a/src/utils/chain.ts
+++ b/src/utils/chain.ts
@@ -1,15 +1,9 @@
-import { Vec, Option, BTreeMap, Tuple, u32, u128 } from '@polkadot/types'
-import type {
-  AccountId,
-  Balance,
-  BalanceOf,
-  BlockNumber,
-} from '@polkadot/types/interfaces'
+import { u32, u128 } from '@polkadot/types'
+import type { Balance } from '@polkadot/types/interfaces'
 import { Candidate, ChainTypes, StakingRates } from '../types'
 import { web3FromAddress } from '@polkadot/extension-dapp'
 import type { SubmittableExtrinsic } from '@polkadot/api/promise/types'
 import { getConnection } from './useConnect'
-import { StakingRates as StakingRatesChain } from '@kiltprotocol/augment-api'
 import { stakingRatesToHuman } from './stakePercentage'
 
 export async function getGenesis() {
@@ -21,10 +15,7 @@ export async function getGenesis() {
 
 export async function getCandidatePool() {
   const api = await getConnection()
-  return api.query.parachainStaking.candidatePool.entries<
-    Option<ChainTypes.Collator>,
-    [AccountId]
-  >()
+  return api.query.parachainStaking.candidatePool.entries()
 }
 
 export const mapCollatorStateToCandidate = (
@@ -45,17 +36,17 @@ export const mapCollatorStateToCandidate = (
 
 export async function getNextCollators() {
   const api = await getConnection()
-  return api.query.session.queuedKeys<Vec<Tuple>>()
+  return api.query.session.queuedKeys()
 }
 
 export async function getCurrentCollators() {
   const api = await getConnection()
-  return api.query.session.validators<Vec<AccountId>>()
+  return api.query.session.validators()
 }
 
 export async function querySessionInfo() {
   const api = await getConnection()
-  const roundInfo = api.query.parachainStaking.round<ChainTypes.RoundInfo>()
+  const roundInfo = api.query.parachainStaking.round()
   return roundInfo
 }
 
@@ -71,28 +62,28 @@ export async function queryBestFinalisedBlock() {
 
 export async function queryOverallTotalStake() {
   const api = await getConnection()
-  return api.query.parachainStaking.totalCollatorStake<ChainTypes.TotalStake>()
+  return api.query.parachainStaking.totalCollatorStake()
 }
 
 export async function queryMaxCandidateCount() {
   const api = await getConnection()
-  return api.query.parachainStaking.maxSelectedCandidates<u32>()
+  return api.query.parachainStaking.maxSelectedCandidates()
 }
 
 export async function queryTotalIssurance() {
   const api = await getConnection()
-  return api.query.balances.totalIssuance<Balance>()
+  return api.query.balances.totalIssuance()
 }
 
 export async function queryMinDelegatorStake(): Promise<u128> {
   const api = await getConnection()
-  return api.consts.parachainStaking.minDelegatorStake as u128
+  return api.consts.parachainStaking.minDelegatorStake
 }
 
 export async function queryStakingRates(): Promise<StakingRates> {
   const api = await getConnection()
   try {
-    const rates = await api.call.staking.getStakingRates<StakingRatesChain>()
+    const rates = await api.call.staking.getStakingRates()
     return stakingRatesToHuman(rates)
   } catch (e) {
     console.warn(e)
@@ -109,12 +100,12 @@ export async function getUnclaimedStakingRewards(
   account: string
 ): Promise<Balance> {
   const api = await getConnection()
-  return api.call.staking.getUnclaimedStakingRewards<Balance>(account)
+  return api.call.staking.getUnclaimedStakingRewards(account)
 }
 
 export async function getMaxNumberDelegators(): Promise<u32> {
   const api = await getConnection()
-  return api.consts.parachainStaking.maxDelegatorsPerCollator as u32
+  return api.consts.parachainStaking.maxDelegatorsPerCollator
 }
 export async function getBalance(account: string) {
   const api = await getConnection()
@@ -123,16 +114,12 @@ export async function getBalance(account: string) {
 
 export async function getUnstakingAmounts(account: string) {
   const api = await getConnection()
-  return api.query.parachainStaking.unstaking<BTreeMap<BlockNumber, BalanceOf>>(
-    account
-  )
+  return api.query.parachainStaking.unstaking(account)
 }
 
 export async function getDelegatorStake(account: string) {
   const api = await getConnection()
-  return api.query.parachainStaking.delegatorState<
-    Option<ChainTypes.Delegator>
-  >(account)
+  return api.query.parachainStaking.delegatorState(account)
 }
 
 export async function signAndSend(

--- a/src/utils/chain.ts
+++ b/src/utils/chain.ts
@@ -1,6 +1,6 @@
-import { u32, u128 } from '@polkadot/types'
+import type { u32, u128 } from '@polkadot/types'
 import type { Balance } from '@polkadot/types/interfaces'
-import { Candidate, ChainTypes, StakingRates } from '../types'
+import type { Candidate, ChainTypes, StakingRates } from '../types'
 import { web3FromAddress } from '@polkadot/extension-dapp'
 import type { SubmittableExtrinsic } from '@polkadot/api/promise/types'
 import { getConnection } from './useConnect'

--- a/src/utils/stakePercentage.ts
+++ b/src/utils/stakePercentage.ts
@@ -1,5 +1,5 @@
 import { Perquintill } from '@polkadot/types/interfaces'
-import { StakingRates as StakingRatesChain } from '@kiltprotocol/augment-api'
+import type { StakingRates as StakingRatesChain } from '@kiltprotocol/augment-api'
 
 export function getPercent(percentageValue: number, secondValue: number) {
   const total = percentageValue + secondValue

--- a/yarn.lock
+++ b/yarn.lock
@@ -4588,15 +4588,14 @@ babel-jest@^27.4.2, babel-jest@^27.5.1:
     graceful-fs "^4.2.9"
     slash "^3.0.0"
 
-babel-loader@8.1.0, babel-loader@^8.2.2, babel-loader@^8.2.3:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.1.0.tgz#c611d5112bd5209abe8b9fa84c3e4da25275f1c3"
-  integrity sha512-7q7nC1tYOrqvUrN3LQK4GwSk/TQorZSOlO9C+RZDZpODgyN4ZlCqE5q9cDsyWOliN+aU9B4JX01xK9eJXowJLw==
+babel-loader@^8.2.2, babel-loader@^8.2.3:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.3.0.tgz#124936e841ba4fe8176786d6ff28add1f134d6a8"
+  integrity sha512-H8SvsMF+m9t15HNLMipppzkC+Y2Yq+v3SonZyU70RBL/h1gxPkH08Ot8pEE9Z4Kd+czyWJClmFS8qzIP9OZ04Q==
   dependencies:
-    find-cache-dir "^2.1.0"
-    loader-utils "^1.4.0"
-    mkdirp "^0.5.3"
-    pify "^4.0.1"
+    find-cache-dir "^3.3.1"
+    loader-utils "^2.0.0"
+    make-dir "^3.1.0"
     schema-utils "^2.6.5"
 
 babel-plugin-add-react-displayname@^0.0.5:
@@ -9860,7 +9859,7 @@ loader-utils@2.0.0, loader-utils@^2.0.0:
     emojis-list "^3.0.0"
     json5 "^2.1.2"
 
-loader-utils@^1.2.3, loader-utils@^1.4.0:
+loader-utils@^1.2.3:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.0.tgz#c579b5e34cb34b1a74edc6c1fb36bfa371d5a613"
   integrity sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==
@@ -9990,7 +9989,7 @@ make-dir@^2.0.0, make-dir@^2.1.0:
     pify "^4.0.1"
     semver "^5.6.0"
 
-make-dir@^3.0.0, make-dir@^3.0.2:
+make-dir@^3.0.0, make-dir@^3.0.2, make-dir@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.1.0.tgz#415e967046b3a7f1d185277d84aa58203726a13f"
   integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1763,17 +1763,17 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@kiltprotocol/augment-api@^0.30.0-rc.1":
-  version "0.30.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/augment-api/-/augment-api-0.30.0-rc.1.tgz#e6f90469a81e11af3e88961481b17d206c2b6efb"
-  integrity sha512-hxixoqbhUt3ILmCAebR45CgnSkX1cNllOCP9qTuqwedLe1m5WJMyp9ajUw+8mTlXLqxVA25+f9usKExuYlEYww==
+"@kiltprotocol/augment-api@^0.30.0":
+  version "0.30.0"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/augment-api/-/augment-api-0.30.0.tgz#ea72bbcc8b834c2c27cca87f2de600d542742015"
+  integrity sha512-+c1dTn8FtrvwJGyrDlpmzrRcFqWVTNAbAF4cJ62eDyPAos2mRvIPmwLKQZceECRI/xGcFHa0wBcW+qgTKL2J5A==
   dependencies:
-    "@kiltprotocol/type-definitions" "0.30.0-rc.1"
+    "@kiltprotocol/type-definitions" "0.30.0"
 
-"@kiltprotocol/type-definitions@0.30.0-rc.1", "@kiltprotocol/type-definitions@^0.30.0-rc.1":
-  version "0.30.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/type-definitions/-/type-definitions-0.30.0-rc.1.tgz#d516aea53de575baec8c0b50685ffda4d9001488"
-  integrity sha512-D41Svo4E6kt5RFb2FzEE50mcTuH8G6ijbBhjN3fd/ZhTe7ZquB6GypEB9ZL/pOh60LhOc9oJPOH07DF3Rvi1mg==
+"@kiltprotocol/type-definitions@0.30.0", "@kiltprotocol/type-definitions@^0.30.0":
+  version "0.30.0"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/type-definitions/-/type-definitions-0.30.0.tgz#00e99636a1c4405071021242cd509090c8f14287"
+  integrity sha512-1UpPDjX8PFqTFm3lRRfYUPEY9M8KrbpRinf4q4K843lY5GdTxQaevrVdK9/WCHKywLyDa4tSrlUv9KQjrTP4bg==
 
 "@leichtgewicht/ip-codec@^2.0.1":
   version "2.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5234,9 +5234,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001335, caniuse-lite@^1.0.30001359:
-  version "1.0.30001361"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001361.tgz#ba2adb2527566fb96f3ac7c67698ae7fc495a28d"
-  integrity sha512-ybhCrjNtkFji1/Wto6SSJKkWk6kZgVQsDq5QI83SafsF6FXv2JB4df9eEdH6g8sdGgqTXrFLjAxqBGgYoU3azQ==
+  version "1.0.30001443"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001443.tgz#8fc85f912d5471c9821acacf9e715c421ca0dd1f"
+  integrity sha512-jUo8svymO8+Mkj3qbUbVjR8zv8LUGpGkUM/jKvc9SO2BvjCI980dp9fQbf/dyLs6RascPzgR4nhAKFA4OHeSaA==
 
 capture-exit@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1903,7 +1903,7 @@
     schema-utils "^3.0.0"
     source-map "^0.7.3"
 
-"@polkadot/api-augment@9.6.2", "@polkadot/api-augment@^9.6.2":
+"@polkadot/api-augment@9.6.2":
   version "9.6.2"
   resolved "https://registry.yarnpkg.com/@polkadot/api-augment/-/api-augment-9.6.2.tgz#a6e7c29d8a06c0951d37796f56bf54530bbc04f0"
   integrity sha512-XsRSXCeZV+pdoY35fhoiHO/sVCmTdfb1lhnpkqEDmucOvP4lBRdg/y2l+50jmftJxnvYD5p/ddVc6ezOJVmL0w==


### PR DESCRIPTION
Use the full sdk release instead of a release candidate; also take advantage of the api augmentation provided by the sdk since 0.29 instead of manually defining on-chain types.
Finally, remove a forced resolution of a babel dependency whose motivation is unclear. 