### PR TITLE
fix: compatibility with did runtime api V2

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "license": "BSD-4-Clause",
   "dependencies": {
-    "@kiltprotocol/augment-api": "^0.31.0",
-    "@kiltprotocol/type-definitions": "^0.31.0",
+    "@kiltprotocol/augment-api": "^0.32.0-rc.2",
+    "@kiltprotocol/type-definitions": "^0.32.0-rc.2",
     "@polkadot/api": "^9.10.2",
     "@polkadot/extension-dapp": "^0.44.8",
     "@polkadot/types": "^9.10.2",

--- a/src/components/Collator/Collator.tsx
+++ b/src/components/Collator/Collator.tsx
@@ -16,7 +16,15 @@ export const Collator: React.FC<Props> = ({ address }) => {
   useEffect(() => {
     const getWeb3name = async () => {
       const api = await getConnection()
-      const connectedDid = await api.call.did.queryByAccount(address)
+      // figure out which did runtime api version we are dealing with
+      const { sectionHash } = api.call.did.queryByAccount.meta
+      const apiVersion = api.runtimeVersion.apis
+        .find(([hash]) => hash.toHex() === sectionHash)![1]
+        .toNumber()
+      // api v2 expects a different parameter format than api v1
+      const connectedDid = await api.call.did.queryByAccount(
+        apiVersion >= 2 ? { AccountId32: address } : address
+      )
       if (connectedDid.isSome) {
         const web3name = connectedDid.unwrap().w3n
         if (web3name.isSome) {

--- a/src/components/Collator/Collator.tsx
+++ b/src/components/Collator/Collator.tsx
@@ -19,7 +19,7 @@ export const Collator: React.FC<Props> = ({ address }) => {
       // figure out which did runtime api version we are dealing with
       const { sectionHash } = api.call.did.queryByAccount.meta
       const apiVersion = api.runtimeVersion.apis
-        .find(([hash]) => hash.toHex() === sectionHash)![1]
+        .find(([hash]) => hash.eq(sectionHash))![1]
         .toNumber()
       // api v2 expects a different parameter format than api v1
       const connectedDid = await api.call.did.queryByAccount(

--- a/yarn.lock
+++ b/yarn.lock
@@ -1763,17 +1763,17 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@kiltprotocol/augment-api@^0.31.0":
-  version "0.31.0"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/augment-api/-/augment-api-0.31.0.tgz#edfa539066e6f5c3e3194ba691138f059de9bd7f"
-  integrity sha512-aequQm+jlu8JjoQB/l+XcX+Aeh5EIw9p9puxiTr1Q8b4MMlII7Td2FgOOyhLntRToYS+ydj+ic8EoFiebh/kTw==
+"@kiltprotocol/augment-api@^0.32.0-rc.2":
+  version "0.32.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/augment-api/-/augment-api-0.32.0-rc.2.tgz#379347a1cc02513eeef5bb1211c4c53df963537d"
+  integrity sha512-4CqJs+ONj07B0LBKN43lGoXVVjvli4otcXq5J75AMSW2+xYfq70uXqQeOqJ56H13fWesFjJ5v+mSFh1vbaZG4w==
   dependencies:
-    "@kiltprotocol/type-definitions" "0.31.0"
+    "@kiltprotocol/type-definitions" "0.32.0-rc.2"
 
-"@kiltprotocol/type-definitions@0.31.0", "@kiltprotocol/type-definitions@^0.31.0":
-  version "0.31.0"
-  resolved "https://registry.yarnpkg.com/@kiltprotocol/type-definitions/-/type-definitions-0.31.0.tgz#455ee5984432a5ff4da69a2edd227e6cc49e7dc9"
-  integrity sha512-bgIYXQyROWNDmQ7RJ8o5wsC6pEIsR9al+M8CKfA4feVv7HjtcHVfBYodmd4drk/O12xtAJE9KK//2wqM7F+tig==
+"@kiltprotocol/type-definitions@0.32.0-rc.2", "@kiltprotocol/type-definitions@^0.32.0-rc.2":
+  version "0.32.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@kiltprotocol/type-definitions/-/type-definitions-0.32.0-rc.2.tgz#eb0e0afd61527c1a28de01fc42a6db430e9bdbdc"
+  integrity sha512-q/M32lw6pdapPPnP8w6yErl1g/p27oFXCtHQBVUE3jsG5JNpSyu1ptiiJc6OpN17Pwp2b5znugAq7FHp6sb6LQ==
 
 "@leichtgewicht/ip-codec@^2.0.1":
   version "2.0.4"


### PR DESCRIPTION
The upcoming upgrade to did runtime api v2 breaks w3n fetching on stakeboard.

## How to test

Try running stakeboard against a chain using V1 of the api and a chain using V2 of the api (spec version>=11000).