### PR TITLE
fix: claiming of rewards while not delegating

### DIFF
--- a/src/components/RewardsModal/RewardsModal.tsx
+++ b/src/components/RewardsModal/RewardsModal.tsx
@@ -24,7 +24,7 @@ export const RewardModal: React.FC<Props> = ({
   useEffect(() => {
     const getFee = async () => {
       const feeInFemto = (
-        await claimDelegatorRewards().then((tx) =>
+        await claimDelegatorRewards(accountAddress).then((tx) =>
           tx.paymentInfo(accountAddress)
         )
       ).partialFee

--- a/src/container/IdentityView/IdentityView.tsx
+++ b/src/container/IdentityView/IdentityView.tsx
@@ -31,7 +31,7 @@ export const IdentityView: React.FC = () => {
   const handleRewardsClaim = async () => {
     if (!account) throw new Error('No account selected')
 
-    const tx = await claimDelegatorRewards()
+    const tx = await claimDelegatorRewards(account.address)
     await signAndSubmitTx(account.address, tx)
     hideModal()
   }


### PR DESCRIPTION
### fixes https://github.com/KILTprotocol/ticket/issues/2563

Introduces a query to find out if an account is an active delegator during claiming of rewards, as this decides whether or not we need to call `increaseDelegatorRewards`. This call failed when an account was not in the delegators set, preventing you from claiming your rewards.  